### PR TITLE
clarify that merchant generates revlockcom params

### DIFF
--- a/tezos/1-setup.md
+++ b/tezos/1-setup.md
@@ -13,7 +13,6 @@
 
 ## System Setup
 ### Commitment scheme parameters
-* **Pedersen commitments**: We use Pedersen commitments on messages of length one in the pairing group `G1` of BLS12-381. We set parameters as the pair `(g1, h)`, where `g1` is the standard generator defined in the BLS12-381 crate and `h` is a hash-to-curve of the string `'zkChannels Pedersen generator'`.
 * **Hash commitment parameters**:
 We use SHA3-256 hashes to instantiate our hash-based commitments.
 
@@ -34,9 +33,13 @@ We use SHA3-256 hashes to instantiate our hash-based commitments.
 A party who wishes to act as a zkChannel merchant must generate and publish the following parameters for use across all of their zkChannels: 
 
 * **Blind signature public key pair.** The merchant must use this key pair to sign all channel state initializations and updates in `zkAbacus`. This keypair is also used as a condition in the Tezos smart contract for each channel. 
+
 * **Range proof public key pair and signatures.** The `zkAbacus.Pay` protocol requires a separate set of parameters to prove that updated channel balances are valid. A range proof demonstrates that a value (in our case, an updated channel balance) is non-negative. Specifically, we use range proofs to show that an integer is in the range `[0, u^l)`, for integer values `u`, `l`. We set `u = 128` and `l = 9`. This primitive relies on Poincheval Sanders signatures.
 
+* **Revocation lock commitment parameters.** The `zkAbacus.Pay` protocol requires a set of Pedersen commitment parameters on messages of length one in the pairing group `G1` of BLS12-381. These are used to prove that the customer reveals the correct revocation lock.
+
 * **EdDSA public key pair and Tezos tz1 address.** The merchant uses this keypair for escrow account set up and closing as specified in `TezosEscrowAgent`.
+
 
 The merchant must also initialize a database `revocation_DB` for use with all their zkChannel operations.
 
@@ -48,16 +51,22 @@ This key pair must be used across all channels with the merchant.
 
 ### Range proof parameters generation
 
-Generate a [new Pointcheval-Sanders keypair](https://github.com/boltlabs-inc/libzkchannels-crypto/blob/main/libzkchannels-crypto/src/ps_keys.rs#L69) for signatures on message tuples of length one.
-With this keypair, separately [sign](https://github.com/boltlabs-inc/libzkchannels-crypto/blob/main/libzkchannels-crypto/src/ps_signatures.rs#L64) each integer in the range `[0, u-1]`.
+Generate a [new Pointcheval-Sanders keypair](
+https://github.com/boltlabs-inc/libzkchannels-crypto/blob/main/zkchannels-crypto/src/pointcheval_sanders.rs#L255) for signatures on message tuples of length one.
+With this keypair, separately [sign](
+https://github.com/boltlabs-inc/libzkchannels-crypto/blob/main/zkchannels-crypto/src/pointcheval_sanders.rs#L271) each integer in the range `[0, u-1]`.
 
 The resulting public key and signatures form the the merchant's range proof parameters. This keypair must not be used for any other purpose.
+
+### Revocation lock commitment parameters generation
+
+Generate a new set of [Pedersen commitment parameters](https://github.com/boltlabs-inc/libzkchannels-crypto/blob/main/zkchannels-crypto/src/pedersen.rs#L85) for commitments to tuples of length one. 
 
 ### EdDSA and Tezos address generation
 Generate an EdDSA keypair and associated Tezos tz1 address using the `tezos-client`.
 
 ### Publishing public parameters
-The merchant's public parameters consists of their blind signing public key `merch_PS_pk`, range proof parameters `range_proof_params`, EdDSA public key `merch_pk`, and Tezos tz1 address `merch_addr`. 
+The merchant's public parameters consists of their blind signing public key `merch_PS_pk`, range proof parameters `range_proof_params`, revocation commitment parameters `revlock_com_params`, EdDSA public key `merch_pk`, and Tezos tz1 address `merch_addr`. 
 
 The merchant publishes their public parameters in a config file. The merchant then advertises their server IP address and port for customers to open channels using the `<merch_pp_hash>@<ip>:<port>` format, where `merch_pp_hash` is set to `SHA3-256(merch_PS_pk, merch_addr, merch_pk)`.
 

--- a/tezos/2-channel-establishment.md
+++ b/tezos/2-channel-establishment.md
@@ -14,7 +14,7 @@ The merchant has completed the [setup](1-setup.md#merchant-setup) phase, and the
 The customer has [obtained the merchant’s setup information](1-setup.md#publishing-public-parameters) out of band. The customer must verify the merchant's public parameters are well-formed and valid:
 * The merchant blind signing public key `merch_PS_pk` must consist of a valid Pointcheval Sanders public key of the expected length with components in the BLS12-381 pairing subgroups G1 and G2.
 * The range proof parameters `range_proof_params` must consist of a valid Pointcheval Sanders key of the expected length with components in the BLS12-381 pairing subgroup G1, and valid signatures on the appropriate integer range.
-* The pedersen commitment parameters must be well-formed, of the expected length, and consist of elements from the BLS12-381 pairing subgroup G1.
+* The revocation lock commitment parameters `revlock_com_params` must be well-formed Pedersen parameters of the expected length, and consist of elements in the BLS12-381 pairing subgroup G1.
 * The merchant EdDSA public key `merch_pk` must be a valid EdDSA key for the curve specified by `tezos-client` and the merchant address `merch_addr` must be a Tezos tz1 address correctly derived from `merch_pk`. 
 
 ## Overview


### PR DESCRIPTION
This adds some language that should clarify that the merchant must explicitly create commitment parameters for revocation locks. I didn't find any language that suggested it comes from some pre-generated source - if such a thing exists in this repo, please point it out so I can remove.

closes boltlabs-inc/libzkchannels-crypto#121
and fixes #37 with correct links