### PR TITLE
Add chain watcher.

### DIFF
--- a/tezos/0-overview-and-index.md
+++ b/tezos/0-overview-and-index.md
@@ -19,7 +19,7 @@ A zkChannels network for a given merchant follows a 'hub-and-spoke' topology. A 
 
 zkChannels on Tezos is built out two main components:
 * `zkAbacus`: [The zkAbacus component](https://github.com/boltlabs-inc/blindsigs-protocol/releases/download/ecc-review/zkchannels-protocol-spec-v3.pdf) contains the functionality for a customer and a merchant to open, track payments, and collaboratively close a channel. This component does not interact with a blockchain.
-* `TezosEscrowAgent`: [The TezosEscrowAgent component](5-tezos-escrowagent.md) provides the functionality for a customer and a merchant to open and close a zkChannels escrow account as a Tezos smart contract. Formally, this is a realization of the [zkEscrowAgent functionality](https://github.com/boltlabs-inc/blindsigs-protocol/releases/download/ecc-review/zkchannels-protocol-spec-v3.pdf) for Tezos. 
+* `TezosEscrowAgent`: [The TezosEscrowAgent component](5-tezos-escrowagent.md) provides the functionality for a customer and a merchant to open and close a zkChannels escrow account as a Tezos smart contract. Formally, this is a realization of the [zkEscrowAgent functionality](https://github.com/boltlabs-inc/blindsigs-protocol/releases/download/ecc-review/zkchannels-protocol-spec-v3.pdf) for Tezos. This realization must include [chain watcher functionality](5-tezos-escrowagent#tezos-chain-watcher-requirements) in order for channel participants to track escrow account updates and [client functionality](5-tezos-escrowagent#tezos-client-requirements) to actively interact with the chain.
 
 We briefly describe the protocol in four phases: System Setup and Merchant Initialization, Channel Establishment, Channel Payments, and Channel Closure.
 

--- a/tezos/1-setup.md
+++ b/tezos/1-setup.md
@@ -68,7 +68,7 @@ The resulting public key and signatures form the the merchant's range constraint
 Generate a new set of [Pedersen commitment parameters](https://github.com/boltlabs-inc/libzkchannels-crypto/blob/main/zkchannels-crypto/src/pedersen.rs#L85) for commitments to tuples of length one. 
 
 ### EdDSA and Tezos address generation
-The user can specify an EdDSA keypair and associated Tezos address. They can use an existing keypair or generate a new one using the `tezos-client`.
+The merchant can specify an EdDSA keypair and associated Tezos address. They can use an existing keypair or generate a new one using the `tezos-client`.
 
 ### Publishing public parameters
 The merchant's public parameters consist of their blind signing public key `merchant_zkabacus_public_key`, parameters for constructing range constraints `range_constraint_parameters`, revocation commitment parameters `revocation_commitment_parameters`, EdDSA public key `merchant_public_key`, and Tezos tz1 address `merchant_address`. 

--- a/tezos/2-channel-establishment.md
+++ b/tezos/2-channel-establishment.md
@@ -223,7 +223,7 @@ Upon receipt, the customer:
 
 #### Merchant Requirements
 Before sending, the merchant:
-  - In the single-funded case, the contract status must be `OPEN` for `required_confirmations` blocks.
+  - In the single-funded case, the merchant checks that contract status has been `OPEN` for `required_confirmations` blocks.
   - In the dual-funded cases, the chain watcher must indicate that the contract storage status has been set to `OPEN` for `required_confirmations` blocks.
   - Generates the `activate` message by running `zkAbacus.Activate()` on the initial state commitment `state_commitment` provided in the customer's `init_c` message, the channel identifier `channel_id`, and their Pointcheval Sanders public key.
   - Updates the channel status to `Active`.

--- a/tezos/2-channel-establishment.md
+++ b/tezos/2-channel-establishment.md
@@ -74,7 +74,7 @@ The protocol proceeds as follows:
       c.  They fund the contract by calling the [`addCustFunding` entrypoint](5-tezos-escrowagent.md#addcustfunding-entrypoint) of the contract. The source of this transfer operation must be the `customer_address` specified in the contract's initial storage and the transfer amount must be equal to `init_customer_balance`. When the chain watcher indicates that the `addCustFunding` operation group is confirmed to the depth `required_confirmations`, they update the channel status to `CustomerFunded`.
       
 6. The customer sends the [`funding_confirmed` message](#the-funding_confirmed-message) to the merchant, which contains the contract identifier `contract-id`.
-7. The merchant [checks the corresponding contract and initial storage for the expected values](#merchant-requirements-4) and initializes the chain watcher to track the zkChannels contract specified by `contract_ID`. The merchant then funds their side of the smart contract, if the channel is dual-funded, by calling the [`AddMerchFunding` entrypoint](5-tezos-escrowagent.md#addmerchfunding-entrypoint) of the contract with identifier `contract_id`. Once this contract has status `OPEN` for `required_confirmations` blocks, the merchant runs `zkAbacus.Activate()` to generate the initial payment tag and sends the customer [the message `activate`](#the-activate-message), which contains this payment tag. 
+7. The merchant [checks the corresponding contract and initial storage for the expected values](#merchant-requirements-4) and initializes the chain watcher to track the zkChannels contract specified by `contract_ID`. The merchant then funds their side of the smart contract, if the channel is dual-funded, by calling the [`AddMerchFunding` entrypoint](5-tezos-escrowagent.md#addmerchfunding-entrypoint) of the contract with identifier `contract_id`. When the chain watcher indicates  this contract has status `OPEN` for a depth of `required_confirmations` blocks, the merchant runs `zkAbacus.Activate()` to generate the initial payment tag and sends the customer [the message `activate`](#the-activate-message), which contains this payment tag. 
 8. Upon completion of `zkAbacus.Activate()`, the zkChannel is open and ready for [payments](3-channel-payments.md). 
 
 
@@ -223,7 +223,6 @@ Upon receipt, the customer:
 
 #### Merchant Requirements
 Before sending, the merchant:
-  - In the single-funded case, the merchant checks that contract status has been `OPEN` for `required_confirmations` blocks.
-  - In the dual-funded cases, the chain watcher must indicate that the contract storage status has been set to `OPEN` for `required_confirmations` blocks.
-  - Generates the `activate` message by running `zkAbacus.Activate()` on the initial state commitment `state_commitment` provided in the customer's `init_c` message, the channel identifier `channel_id`, and their Pointcheval Sanders public key.
+  - The chain watcher must indicate that the contract storage status has been set to `OPEN` for `required_confirmations` blocks.
+  - Generates the `activate` message by running `zkAbacus.Activate()` on the initial state commitment `state_commitment` provided in the customer's `init_c` message, the channel identifier `channel_id`, and their zkAbacus Pointcheval Sanders public key.
   - Updates the channel status to `Active`.

--- a/tezos/2-channel-establishment.md
+++ b/tezos/2-channel-establishment.md
@@ -69,13 +69,13 @@ The protocol proceeds as follows:
       * `merchant_public_key`: The merchant's Tezos public key.
       * `merchant_zkabacus_public_key`: The merchant's zkAbacus public key.
 
-      b.  They inject the [origination operation](5-tezos-escrowagent.md#zkchannels-contract-origination-operation). They wait until this operation is confirmed to depth `required_confirmations` and then they update their channel status to `Originated`.
+      b.  They inject the [origination operation](5-tezos-escrowagent.md#zkchannels-contract-origination-operation). They compute the contract identifier `contract_ID` and initialize the [chain watcher](5-tezos-escrowagent#tezos-chain-watcher-requirements) to track the zkchannels contract with identifier `contract_ID`. When the chain watcher indicates that the origination operation is confirmed to depth `required_confirmations`, they update their channel status to `Originated`.
 
-      c.  They fund the contract by calling the [`addCustFunding` entrypoint](5-tezos-escrowagent.md#addcustfunding-entrypoint) of the contract. The source of this transfer operation must be the `customer_address` specified in the contract's initial storage and transfer amount must be equal to `init_customer_balance`. They wait until the `addCustFunding` operation group is confirmed to the depth `required_confirmations` and then update the channel status to `CustomerFunded`.
+      c.  They fund the contract by calling the [`addCustFunding` entrypoint](5-tezos-escrowagent.md#addcustfunding-entrypoint) of the contract. The source of this transfer operation must be the `customer_address` specified in the contract's initial storage and the transfer amount must be equal to `init_customer_balance`. When the chain watcher indicates that the `addCustFunding` operation group is confirmed to the depth `required_confirmations`, they update the channel status to `CustomerFunded`.
       
 6. The customer sends the [`funding_confirmed` message](#the-funding_confirmed-message) to the merchant, which contains the contract identifier `contract-id`.
-7. The merchant [checks the corresponding contract and initial storage for the expected values](#merchant-requirements-4). The merchant then funds their side of the smart contract, if the channel is dual-funded, by calling the [`AddMerchFunding` entrypoint](5-tezos-escrowagent.md#addmerchfunding-entrypoint) of the contract with identifier `contract_id`. Once this contract has status `OPEN` for `required_confirmations` blocks, the merchant runs `zkAbacus.Activate()` to generate the initial payment tag and sends the customer [the message `activate`](#the-activate-message), which contains this payment tag. 
-8. Upon completion of `zkAbacus.Activate()`, the channel is open and ready for [payments](3-channel-payments.md). 
+7. The merchant [checks the corresponding contract and initial storage for the expected values](#merchant-requirements-4) and initializes the chain watcher to track the zkChannels contract specified by `contract_ID`. The merchant then funds their side of the smart contract, if the channel is dual-funded, by calling the [`AddMerchFunding` entrypoint](5-tezos-escrowagent.md#addmerchfunding-entrypoint) of the contract with identifier `contract_id`. Once this contract has status `OPEN` for `required_confirmations` blocks, the merchant runs `zkAbacus.Activate()` to generate the initial payment tag and sends the customer [the message `activate`](#the-activate-message), which contains this payment tag. 
+8. Upon completion of `zkAbacus.Activate()`, the zkChannel is open and ready for [payments](3-channel-payments.md). 
 
 
 ## Message Specifications
@@ -163,7 +163,7 @@ The merchant sends an `init_m` message to the customer.
 2. data: [`(bls12_381_g1, bls12_381_g1):closing_signature`]. A closing authorization signature on the initial closing state.
  
 #### Customer Requirements
-Upon receipt, the customer verifies `closing_signature` is a valid signature with respect to the merchant zkAbacus Pointcheval Sanders public key. If the signature is valid, the customer continues as specified in `zkAbacus.Initialize()`. If the signaure is invalid, the customer aborts.
+Upon receipt, the customer verifies `closing_signature` is a valid signature with respect to the merchant zkAbacus Pointcheval Sanders public key. If the signature is valid, the customer continues as specified in `zkAbacus.Initialize()`. If the signature is invalid, the customer aborts.
 
 #### Merchant Requirements
 The merchant runs `zkAbacus.Initialize` on inputs `channel_id`, `init_customer_balance`, and `init_merchant_balance`. If successful, the merchant sends the resulting message `init_m`. Otherwise, the merchant aborts.
@@ -179,17 +179,20 @@ The customer sends the `funding_confirmed` message to the merchant.
 #### Customer Requirements
 
 The customer:
-  - Originates and funds the contract as specified in the [Tezos zkEscrowAgent Realization document](5-tezos-escrowagent.md#zkchannels-customer-origination-and-funding-protocol).
-  - Waits until the origination operation is confirmed on chain for at least `required_confirmations` blocks. 
+  - Originates and funds the contract as specified in the [Tezos zkEscrowAgent Realization document](5-tezos-escrowagent.md#zkchannels-customer-origination-and-funding-protocol) and computes the contract identifier `contract_ID`.
+  - Initializes the [chain watcher](5-tezos-escrowagent#tezos-chain-watcher-requirements) to track the contract with identifier `contract_ID`.
+  - Receives a notification from the chain watcher that the origination operation for the contract specified by `contract_ID` is confirmed on chain for at least `required_confirmations` blocks. 
   - Updates the channel status to `Originated`.
   - Funds the contract by calling the [`addCustomerFunding` entrypoint](5-tezos-escrow-agent#addCustFunding-entrypoint).
-  - Waits until the funding operation is confirmed on chain for at least `required_confirmations` blocks. 
+  - Receives a notification from the chain watcher that the funding operation is confirmed on chain for at least `required_confirmations` blocks. 
   - Updates the channel status to `CustomerFunded`.
   - Sends the `funding_confirmed` message to the merchant.
 
 #### Merchant Requirements
 Upon receipt of the `funding_confirmed` message, the merchant: 
+  - Initializes the [chain watcher](5-tezos-escrowagent#tezos-chain-watcher-requirements) to track the contract with identifier `contract_ID`.
   - Checks that the originated contract `contract-id` contains the expected [zkchannels contract](https://github.com/boltlabs-inc/tezos-contract/blob/main/zkchannels-contract/zkchannel_contract.tz) with respect to the channel identifier `channel_id`, the customer Tezos public key `customer_public_key`, the customer's tezos tz1 address `customer_address`, the merchant public parameters, and the initial balances `init_customer_balance` and `init_merchant_balance`.
+  
   - Checks that the on-chain storage of `contract-id` at `originated-block-height` is exactly as expected for channel `channel_id`:
     - The contract storage contains `merchant_zkabacus_public_key` in the expected field(s).
     - The customer's tezos tz1 address and public key match the fields `customer_address` and  `customer_public_key`, respectively.
@@ -199,12 +202,11 @@ Upon receipt of the `funding_confirmed` message, the merchant:
     - The fields `customer_balance` and `merchant_balance` are initialized to `init_customer_balance` and `init_merchant_balance`, respectively.
     - The `status` field of the contract is initialized to `AWAITING_CUST_FUNDING`.
     - The `context-string` is set to `"zkChannels mutual close"`, as defined in the [global defaults](1-setup.md#Global-defaults). 
-  - Waits until the originated contract is confirmed on chain for at least `required_confirmations` blocks.
+  - Checks that the originated contract is confirmed on chain for at least `required_confirmations` blocks.
   - Updates the channel status to `Originated`.
-  - Checks that the customer has funded the contract and waits until the customer's side of the contract has been funded for at least `required_confirmations` blocks. This requires checking that the customer's operation to add their funds is the last operation to have interacted with the smart contract, and that in the most recent blocks of the blockchain (up to `required_confirmations` blocks in the past) there have been no further operations interacting with the contract. 
+  - Checks that the customer has funded the contract for at least `required_confirmations` blocks. This requires checking that the customer's operation to add their funds is the last operation to have interacted with the smart contract, and that in the most recent blocks of the blockchain (up to `required_confirmations` blocks in the past) there have been no further operations interacting with the contract. 
   - In the dual-funded case, funds their side of the contract by calling the [`addMerchantFunding` entrypoint](#addmerchmunding-entrypoint). The source of this transfer operation must be the `merchant_address` specified in the contract's initial storage and the transfer amount must be equal to `init_merchant_balance`.
-  - Waits until the `addMerchantFunding` operation is confirmed on chain and the contract storage `status` is `OPEN` for at least `required_confirmations` blocks.
-  - Updates the channel status to `MerchantFunded`.
+  - When the chain watcher indicates that the `addMerchantFunding` operation is confirmed on chain and the contract storage `status` is `OPEN` for at least `required_confirmations` blocks, updates the channel status to `MerchantFunded`.
 
   ### The `activate` Message
   The merchant sends the `activate` message to the customer.
@@ -214,13 +216,14 @@ Upon receipt of the `funding_confirmed` message, the merchant:
 
 #### Customer Requirements
 Upon receipt, the customer:
-  - In the dual-funded case, waits for the contract storage status to be `OPEN` for `required_confirmations` blocks before proceeding. Update the channel status to `MerchantFunded`.
+  - In the dual-funded case, when the chain watcher indicates the contract storage status is `OPEN` at a confirmation depth of `required_confirmations`, updates the channel status to `MerchantFunded`.
   - If the customer does not see a confirmed `addMerchantFunding` operation from the merchant within a specified timeout period, they call the [`reclaimFunding` entrypoint](5-tezos-escrowagent#reclaimfunding).
   - Checks that `payment_tag` is a valid signature with respect to the merchant's zkAbacus Pointcheval Sanders public key. If not, aborts by initiating a unilateral close.
   - Updates the channel status to `Ready`.
 
 #### Merchant Requirements
 Before sending, the merchant:
-  - Waits until the contract storage status has been set to `OPEN` for `required_confirmations` blocks.
-  - Generate the `activate` message by running `zkAbacus.Activate()` on the initial state commitment `state_commitment` provided in the customer's `init_c` message, the channel identifier `channel_id`, and their Pointcheval Sanders public key.
+  - In the single-funded case, the contract status must be `OPEN` for `required_confirmations` blocks.
+  - In the dual-funded cases, the chain watcher must indicate that the contract storage status has been set to `OPEN` for `required_confirmations` blocks.
+  - Generates the `activate` message by running `zkAbacus.Activate()` on the initial state commitment `state_commitment` provided in the customer's `init_c` message, the channel identifier `channel_id`, and their Pointcheval Sanders public key.
   - Updates the channel status to `Active`.

--- a/tezos/5-tezos-escrowagent.md
+++ b/tezos/5-tezos-escrowagent.md
@@ -143,9 +143,10 @@ We assume that the minimal operation fee will be sufficient for operations to be
 ## Tezos chain watcher requirements
 The Tezos chain watcher allows a party to track the current status of a zkChannels contract. That is, the chain watcher:
 * Provides details of each on-chain contract update to the party, including:
-  * when a transaction has reached the required confirmations depth, `required_confirmations`; and
+  * when an update has reached the required confirmation depth, `required_confirmations`; and
   * when an active timelock has elapsed. 
-* Must be a persistent process from the time of contract origination to the time of contract closure.
+* On initialization, the chain watcher indicates the current state of the contract and whether or not that state has reached a confirmation depth of `required_confirmations`. If the current state is not confirmed to the depth `required_confirmatins`, the chain watcher will indicate when this depth has been reached.
+* Must be a persistent process from the time of chain watcher initialization to the time chain watcher is halted.
 * Must provide update notifications in real time, ie without delays.
 
 ## Tezos client requirements

--- a/tezos/5-tezos-escrowagent.md
+++ b/tezos/5-tezos-escrowagent.md
@@ -13,6 +13,7 @@ It includes support for mutual closes, unilateral closes by either the customer 
       - [Estimating operation gas and storage](#estimating-operation-gas-and-storage)
       - [Minimal operation fees](#minimal-operation-fees)
     - [Fee handling](#fee-handling)
+  - [Tezos chain watcher requirements](#tezos-chain-watcher-requirements)
   - [Tezos client requirements](#tezos-client-requirements)
   - [zkChannels Contract](#zkchannels-contract)
     - [Initial contract arguments](#initial-contract-arguments)
@@ -138,6 +139,14 @@ The default minimal fee values are below. For more details see the tezos [develo
 
 ### Fee handling
 We assume that the minimal operation fee will be sufficient for operations to be confirmed. As such, operations are forged using the minimal operation fee. This specification does not handle the case where the minimal operation fee is insufficient for bakers to include the operation into a block. 
+
+## Tezos chain watcher requirements
+The Tezos chain watcher allows a party to track the current status of a zkChannels contract. That is, the chain watcher:
+* Provides details of each on-chain contract update to the party, including:
+  * when a transaction has reached the required confirmations depth, `required_confirmations`; and
+  * when an active timelock has elapsed. 
+* Must be a persistent process from the time of contract origination to the time of contract closure.
+* Must provide update notifications in real time, ie without delays.
 
 ## Tezos client requirements
 The Tezos client is used to interact with the Tezos node for performing actions as creating operations, injecting operations and querying the state of the blockchain. We assume each party has a Tezos client capable of the following:

--- a/tezos/customer-database.md
+++ b/tezos/customer-database.md
@@ -68,7 +68,7 @@ The closing procedure can begin from many statuses, but in a normal run, we expe
    _______________________________________/-> PendingMutualClose 
   |                                                              \
   |             __________________________________________________\ 
-  |            |               \                                   \
+  |            |                                                   \
 Ready -> PendingExpiry -> PendingClose -> PendingCustomerClaim -> Closed
   |_______________________/     |                                  /
                                 |-> Dispute_______________________/

--- a/tezos/customer-database.md
+++ b/tezos/customer-database.md
@@ -67,7 +67,7 @@ The closing procedure can begin from many statuses, but in a normal run, we expe
 ```
    _______________________________________/-> PendingMutualClose 
   |                                                              \
-  |             _____________________________                     \ 
+  |             __________________________________________________\ 
   |            |                             \                     \
 Ready -> PendingExpiry -> PendingClose -> PendingCustomerClaim -> Closed
   |_______________________/     |                                  /

--- a/tezos/customer-database.md
+++ b/tezos/customer-database.md
@@ -68,7 +68,7 @@ The closing procedure can begin from many statuses, but in a normal run, we expe
    _______________________________________/-> PendingMutualClose 
   |                                                              \
   |             __________________________________________________\ 
-  |            |                             \                     \
+  |            |               \                                   \
 Ready -> PendingExpiry -> PendingClose -> PendingCustomerClaim -> Closed
   |_______________________/     |                                  /
                                 |-> Dispute_______________________/


### PR DESCRIPTION
Fixes #89 
Fixes #78

This PR adds a chain watcher to the specification and makes some fixes with respect to related channel status updates. 

Of note:
- The customer channel status updates did not allow for a transition from `PendingExpiry` to `Closed`.
